### PR TITLE
Discussion: move jupyterhub config and form from docker image  to deployment yaml

### DIFF
--- a/SWAN.yaml
+++ b/SWAN.yaml
@@ -138,6 +138,12 @@ spec:
           mountPath: /var/log/httpd
         - name: &vm_logs-shibboleth shibboleth-logs
           mountPath: /var/log/shibboleth
+        - name: &vm_swan-config swan-config
+          mountPath: /srv/jupyterhub/jupyterhub_form.complete.html # TODO: /srv/jupyterhub/jupyterhub_form.html ?
+          subPath: jupyterhub_form.complete.html
+        - name: &vm_swan-config swan-config
+          mountPath: /root/jupyterhub_config/kubespawner.py # TODO: /srv/jupyterhub/jupyterhub_config.py ?
+          subPath: kubespawner.py
         env:
         - name: PODINFO_NAMESPACE
           valueFrom:
@@ -163,6 +169,8 @@ spec:
           value: "JUPYTERHUB"
         - name: DEPLOYMENT_TYPE
           value: "kubespawner"
+        - name: SPAWNER_FORM
+          value: "complete"
         #- name: HOSTNAME                 # Use this configuration only if the linux hostname matches the chosen domain name
         #  valueFrom:                     # at the DNS (e.g., no aliases are defined)
         #    fieldRef:                    # Otherwise, please specify manually the hostname below. 
@@ -202,10 +210,9 @@ spec:
           value: "/cvmfs"
         - name: EOS_USER_PATH           # This must bring to the folder with the list of initials of users
           value: "/eos/docker/user"     # E.g., "/eos/docker/user" --(will be mapped to)--> "/eos/user" in the container
+          # TODO: use directly CERNBOXGATEWAY_HOSTNAME in jupyterhub config ?
         - name: CERNBOXGATEWAY_HOSTNAME     # Hostname of CERNBox for Sharing API
           value: "up2kube-cernbox.cern.ch"
-        # - name: SPAWNER_FORM
-        #   value: "simple"
         #### Customization
         #- name: CUSTOMIZATION_REPO
         #  value: "https://<something>.git"
@@ -236,6 +243,14 @@ spec:
         hostPath:
           path: /var/kubeVolumes/shibboleth_logs
           type: DirectoryOrCreate
+      - name: *vm_swan-config
+        configMap:
+          name: swan-config
+          items:
+          - key: kubespawner.py
+            path: kubespawner.py
+          - key: jupyterhub_form.complete.html
+            path: jupyterhub_form.complete.html
 
 ---
 # SQUID Proxy for CVMFS -- Deployment
@@ -556,4 +571,260 @@ spec:
 #    targetPort: 443
 #    nodePort: 30443
 #  type: NodePort
+
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: &name swan-config
+  namespace: &namespace swan
+data:
+  kubespawner.py: |-
+    ###
+    # Remember to authorize the pod where JupyterHub runs to access the API
+    # of the cluster and to list pods in the namespace
+    #
+    # As temporary workaround:
+    # kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=boxed:default
+    ###
+
+    # Configuration file for JupyterHub
+    import os
+    import socket
+
+
+    ### VARIABLES ###
+    # Get configuration parameters from environment variables
+    CVMFS_FOLDER            = os.environ['CVMFS_FOLDER']
+    EOS_USER_PATH           = os.environ['EOS_USER_PATH']
+    CONTAINER_IMAGE         = os.environ['CONTAINER_IMAGE']
+    LDAP_URI                = os.environ['LDAP_URI']
+    LDAP_PORT               = os.environ['LDAP_PORT']
+    LDAP_BASE_DN            = os.environ['LDAP_BASE_DN']
+    NAMESPACE               = os.environ['PODINFO_NAMESPACE']
+    NODE_SELECTOR_KEY       = os.environ['NODE_SELECTOR_KEY']
+    NODE_SELECTOR_VALUE     = os.environ['NODE_SELECTOR_VALUE']
+
+
+    c = get_config()
+
+    ### Configuration for JupyterHub ###
+    # JupyterHub runtime configuration
+    jupyterhub_runtime_dir = '/srv/jupyterhub/jupyterhub_data/'
+    os.makedirs(jupyterhub_runtime_dir, exist_ok=True)
+    c.JupyterHub.cookie_secret_file = os.path.join(jupyterhub_runtime_dir, 'cookie_secret')
+    c.JupyterHub.db_url = os.path.join(jupyterhub_runtime_dir, 'jupyterhub.sqlite')
+
+    # Resume previous state if the Hub fails
+    c.JupyterHub.cleanup_proxy = False      # Do not kill the proxy if the hub fails (will return 'Service Unavailable')
+    c.JupyterHub.cleanup_servers = False    # Do not kill single-user's servers (SQLite DB must be on persistent storage)
+
+    # Logging
+    c.JupyterHub.log_level = 'DEBUG'
+    c.Spawner.debug = True
+    c.LocalProcessSpawner.debug = True
+
+    # Add SWAN look&feel
+    c.JupyterHub.template_paths = ['/srv/jupyterhub/jh_gitlab/templates']
+    c.JupyterHub.logo_file = '/usr/local/share/jupyterhub/static/swan/logos/logo_swan_cloudhisto.png'
+
+    # Reach the Hub from outside
+    c.JupyterHub.ip = "0.0.0.0"     # Listen on all IPs for HTTP traffic when in Kubernetes
+    c.JupyterHub.port = 8000	# You may end up in detecting the wrong IP address due to:
+                                #       - Kubernetes services in front of Pods (headed//headless//clusterIPs)
+                                #       - hostNetwork used by the JupyterHub Pod
+
+    c.JupyterHub.cleanup_servers = False
+    # Use local_home set to true to prevent calling the script that updates EOS tickets
+    c.JupyterHub.services = [
+        {
+            'name': 'cull-idle',
+            'admin': True,
+            'command': 'python3 /srv/jupyterhub/jh_gitlab/scripts/cull_idle_servers.py --cull_every=600 --timeout=14400 --local_home=True --cull_users=True'.split(),
+        }
+    ]
+
+    # Reach the Hub from Jupyter containers
+    # NOTE: The Hub IP must be known and rechable from spawned containers
+    # 	Leveraging on the FQDN makes the Hub accessible both when the JupyterHub Pod
+    #	uses the Kubernetes overlay network and the host network
+    try:
+      hub_ip = socket.gethostbyname(socket.getfqdn())
+    except:
+      print ("WARNING: Unable to identify iface IP from FQDN")
+      s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+      s.connect(("8.8.8.8", 80))
+      hub_ip = s.getsockname()[0]
+    hub_port = 8080
+    c.JupyterHub.hub_ip = hub_ip
+    c.JupyterHub.hub_port = hub_port
+    c.KubeSpawner.hub_connect_ip = hub_ip
+    c.KubeSpawner.hub_connect_port = hub_port
+
+    # Proxy
+    # Wrap the start of the proxy to allow bigger headers in nodejs
+    c.ConfigurableHTTPProxy.command = '/srv/jupyterhub/jh_gitlab/scripts/start_proxy.sh'
+
+    # Load the list of users with admin privileges and enable access
+    admins = set(open(os.path.join(os.path.dirname(__file__), 'adminslist'), 'r').read().splitlines())
+    c.Authenticator.admin_users = admins
+    c.JupyterHub.admin_access = True
+
+    ### User Authentication ###
+    if ( os.environ['AUTH_TYPE'] == "shibboleth" ):
+        print ("Authenticator: Using user-defined authenticator")
+        c.JupyterHub.authenticator_class = '%%%SHIBBOLETH_AUTHENTICATOR_CLASS%%%'
+        # %%% Additional SHIBBOLETH_AUTHENTICATOR_CLASS parameters here %%% #
+
+    elif ( os.environ['AUTH_TYPE'] == "local" ):
+        print ("Authenticator: Using LDAP")
+        c.JupyterHub.authenticator_class = 'ldapauthenticator.LDAPAuthenticator'
+        c.LDAPAuthenticator.server_address = LDAP_URI
+        c.LDAPAuthenticator.use_ssl = False
+        c.LDAPAuthenticator.server_port = int(LDAP_PORT)
+        if (LDAP_URI[0:8] == "ldaps://"):
+          c.LDAPAuthenticator.use_ssl = True
+        c.LDAPAuthenticator.bind_dn_template = 'uid={username},'+LDAP_BASE_DN
+
+    else:
+        print ("ERROR: Authentication type not specified.")
+        print ("Cannot start JupyterHub.")
+
+
+    ### Configuration for single-user containers ###
+
+    # Spawn single-user's servers in the Kubernetes cluster
+    c.JupyterHub.spawner_class = 'swanspawner.SwanKubeSpawner'
+    c.SwanSpawner.image = CONTAINER_IMAGE
+    c.SwanSpawner.namespace = NAMESPACE
+    c.SwanSpawner.node_selector = {NODE_SELECTOR_KEY : NODE_SELECTOR_VALUE}  # Where to run user containers
+    c.SwanSpawner.options_form = '/srv/jupyterhub/jupyterhub_form.html'
+    c.SwanSpawner.start_timeout = 30
+
+    # Single-user's servers extra config, CVMFS, EOS
+    #c.SwanSpawner.extra_host_config = { 'cap_drop': ['NET_BIND_SERVICE', 'SYS_CHROOT']}
+
+    #c.SwanSpawner.local_home = True	# $HOME is a volatile scratch space at /scratch/<username>/
+    c.SwanSpawner.local_home = False	# $HOME is on EOS
+    c.SwanSpawner.volume_mounts = [
+        {
+            'name': 'cvmfs',
+            'mountPath': '/cvmfs:shared',
+        },
+        {
+            'name': 'eos',
+            'mountPath': '/eos/user:shared',
+        }
+    ]
+
+    c.SwanSpawner.volumes = [
+        {
+            'name': 'cvmfs',
+            'hostPath': {
+                'path': '/cvmfs',
+                'type': 'Directory',
+            }
+        },
+        {
+            'name': 'eos',
+            'hostPath': {
+                'path': EOS_USER_PATH,
+                'type': 'Directory',
+            }
+        }
+    ]
+    c.SwanSpawner.available_cores = ["2", "4"]
+    c.SwanSpawner.available_memory = ["8", "10"]
+    c.SwanSpawner.check_cvmfs_status = False #For now it only checks if available in same place as Jupyterhub.
+
+    c.SwanSpawner.extra_env = dict(
+        SHARE_CBOX_API_DOMAIN = "https://%%%CERNBOXGATEWAY_HOSTNAME%%%", # TODO: use env directly?
+        SHARE_CBOX_API_BASE   = "/cernbox/swanapi/v1",
+        HELP_ENDPOINT         = "https://raw.githubusercontent.com/swan-cern/help/up2u/"
+    )
+
+    # local_home equal to true to hide the "always start with this config"
+    c.SpawnHandlersConfigs.local_home = True
+    c.SpawnHandlersConfigs.metrics_on = False #For now the metrics are hardcoded for CERN
+    c.SpawnHandlersConfigs.spawn_error_message = """SWAN could not start a session for your user, please try again. If the problem persists, please check:
+    <ul>
+        <li>Do you have a CERNBox account? If not, click <a href="https://%%%CERNBOXGATEWAY_HOSTNAME%%%" target="_blank">here</a>.</li>
+        <li>Check with the service manager that SWAN is running properly.</li>
+    </ul>"""
+  jupyterhub_form.complete.html: |-
+    <style> .nb{ font-weight:normal } </style>
+    <style> .nbs{ font-weight:normal; font-size:small } </style>
+    <script type="text/javascript">
+    <!--
+       function toggle_visibility(id) {
+          var e = document.getElementById(id);
+          if(e.style.display == 'block')
+             e.style.display = 'none';
+          else
+             e.style.display = 'block';
+       }
+    //-->
+    </script>
+    <br>
+    <label for="placeholder">
+    <span class='nb'>Specify the parameters that will be used to contextualise the container which is created for you. See <a target="_blank" href="https://swan.web.cern.ch/content/faq">the online SWAN guide</a> for more details.</span>
+    </label>
+    <br><br>
+    <label for="LCG-rel">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="lcgReleaseDetails">
+       <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
+    </div>
+    </label>
+    <select name="LCG-rel">
+       <option style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0" disabled="disabled">Recommended releases (General Purpose)</option>
+       <option value="LCG_96" selected="">96</option>
+       <option value="LCG_96python3">96 Python3</option>
+       <option style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0" disabled="disabled"></option>
+       <option style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0" disabled="disabled">Development releases (might be unstable)</option>
+       <option value="dev3/latest">Bleeding Edge</option>
+       <option value="dev3python3/latest">Bleeding Edge Python3</option>
+       <option style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0" disabled="disabled"></option>
+       <option style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0" disabled="disabled">Development releases (GPU)</option>
+       <option value="LCG_96py3cu10">Cuda 10 Python3</option>
+    </select>
+    <br>
+    <label for="platform">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="platformDetails">
+       <span class='nb'>The combination of compiler version and flags.</span>
+    </div>
+    </label>
+    <select name="platform">
+       <option value="x86_64-centos7-gcc8-opt" selected="">CentOS 7 (gcc8)</option>
+    </select>
+    <br>
+    <label for="scriptenv">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="scriptenvDetails">
+       <span class='nb'>User-provided bash script to define custom environment variables. The variable CERNBOX_HOME is resolved to the proper /eos/user/u/username directory.</span>
+    </div>
+    </label>
+    <input type="text" name="scriptenv" placeholder="e.g. $CERNBOX_HOME/MySWAN/myscript.sh">
+    <br>
+    <label for="ncores">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="ncoresDetails">
+       <span class='nb'>Number of cores to associate to the container.</span>
+    </div>
+    </label>
+    <select name="ncores">
+        <option value="2" selected>2</option>
+        <option value="4">4</option>
+    </select>
+    <br>
+    <label for="memory">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="memoryDetails">
+       <span class='nb'>Amount of Memory allocated to the container.</span>
+    </div>
+    </label>
+    <select name="memory">
+        <option value="8" selected>8 GB</option>
+        <option value="10">10 GB</option>
+    </select>
+    <input type="hidden" name="spark-cluster" value="none"/>
+
+
 

--- a/SWAN_SingleHost.yaml
+++ b/SWAN_SingleHost.yaml
@@ -160,6 +160,8 @@ spec:
           value: "kubernetes"
         - name: CVMFS_FOLDER
           value: "/cvmfs"
+        - name: SPAWNER_FORM
+          value: "complete"
 
       ###
       # 3. JupyterHub
@@ -189,6 +191,12 @@ spec:
           mountPath: /var/log/httpd
         - name: &vm_logs-shibboleth shibboleth-logs
           mountPath: /var/log/shibboleth
+        - name: &vm_swan-config swan-config
+          mountPath: /srv/jupyterhub/jupyterhub_form.complete.html # TODO: /srv/jupyterhub/jupyterhub_form.html ?
+          subPath: jupyterhub_form.complete.html
+        - name: &vm_swan-config swan-config
+          mountPath: /root/jupyterhub_config/kubernetes.py # TODO: /srv/jupyterhub/jupyterhub_config.py ?
+          subPath: kubernetes.py
         #- name: rdv-eos        # See notes on EOS-FUSE and CVMFS mounts
         #  mountPath: /eos:shared
         #- name: rdv-cvmfs
@@ -247,7 +255,6 @@ spec:
         #### Customization
         #- name: CUSTOMIZATION_REPO
         #  value: "https://<something>.git"
-
       # Volumes declaration
       volumes:
       - name: *vm_swan-certs
@@ -286,6 +293,14 @@ spec:
         hostPath:
           path: /var/kubeVolumes/shibboleth_logs
           type: DirectoryOrCreate
+      - name: *vm_swan-config
+        configMap:
+          name: swan-config
+          items:
+          - key: kubernetes.py
+            path: kubernetes.py
+          - key: jupyterhub_form.complete.html
+            path: jupyterhub_form.complete.html
 
 ---
 ### SERVICE ###
@@ -331,3 +346,217 @@ spec:
 # As a side effect, EOS and CVMFS will be visible on the host machine.
 ###
 ###
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: &name swan-config
+  namespace: &namespace swan
+data:
+  kubernetes.py: |-
+    # Configuration file for JupyterHub
+    import os
+    import socket
+
+
+    ### VARIABLES ###
+    # Get configuration parameters from environment variables
+    DOCKER_NETWORK_NAME     = os.environ['DOCKER_NETWORK_NAME']
+    CVMFS_FOLDER            = os.environ['CVMFS_FOLDER']
+    EOS_USER_PATH           = os.environ['EOS_USER_PATH']
+    CONTAINER_IMAGE         = os.environ['CONTAINER_IMAGE']
+    LDAP_URI                = os.environ['LDAP_URI']
+    LDAP_PORT               = os.environ['LDAP_PORT']
+    LDAP_BASE_DN            = os.environ['LDAP_BASE_DN']
+
+    c = get_config()
+
+    ### Configuration for JupyterHub ###
+    # JupyterHub
+    c.JupyterHub.cookie_secret_file = '/srv/jupyterhub/cookie_secret'
+    c.JupyterHub.db_url = '/srv/jupyterhub/jupyterhub.sqlite'
+
+    # Logging
+    c.JupyterHub.log_level = 'DEBUG'
+    c.Spawner.debug = True
+    c.LocalProcessSpawner.debug = True
+
+    # Add SWAN look&feel
+    c.JupyterHub.template_paths = ['/srv/jupyterhub/jh_gitlab/templates']
+    c.JupyterHub.logo_file = '/usr/local/share/jupyterhub/static/swan/logos/logo_swan_cloudhisto.png'
+
+    # Reach the Hub from local httpd (proxypass)
+    c.JupyterHub.ip = "127.0.0.1"
+    c.JupyterHub.port = 8000
+
+    c.JupyterHub.cleanup_servers = False
+    # Use local_home set to true to prevent calling the script that updates EOS tickets
+    c.JupyterHub.services = [
+        {
+            'name': 'cull-idle',
+            'admin': True,
+            'command': 'python3 /srv/jupyterhub/jh_gitlab/scripts/cull_idle_servers.py --cull_every=600 --timeout=14400 --local_home=True --cull_users=True'.split(),
+        }
+    ]
+
+    # Proxy
+    # Wrap the start of the proxy to allow bigger headers in nodejs
+    c.ConfigurableHTTPProxy.command = '/srv/jupyterhub/jh_gitlab/jh_gitlab/scripts/start_proxy.sh'
+
+    # Reach the Hub from Jupyter containers
+    # NOTE: Containers are connected to a separate Docker network: DOCKER_NETWORK_NAME
+    #       The hub must listen on an IP address that is reachable from DOCKER_NETWORK_NAME
+    #       and not on "localhost"||"127.0.0.1" or any other name that could not be resolved
+    #       See also c.SwanSpawner.hub_ip_connect (https://github.com/jupyterhub/jupyterhub/issues/291)
+    try:
+      hub_ip = socket.gethostbyname(socket.getfqdn())
+    except:
+      print ("WARNING: Unable to identify iface IP from FQDN")
+      s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+      s.connect(("8.8.8.8", 80))
+      hub_ip = s.getsockname()[0]
+    hub_port = 8080
+    c.JupyterHub.hub_ip = hub_ip
+    c.JupyterHub.hub_port = 8080
+
+    # Load the list of users with admin privileges and enable access
+    admins = set(open(os.path.join(os.path.dirname(__file__), 'adminslist'), 'r').read().splitlines())
+    c.Authenticator.admin_users = admins
+    c.JupyterHub.admin_access = True
+
+    ### User Authentication ###
+    if ( os.environ['AUTH_TYPE'] == "shibboleth" ):
+        print ("Authenticator: Using user-defined authenticator")
+        c.JupyterHub.authenticator_class = '%%%SHIBBOLETH_AUTHENTICATOR_CLASS%%%'
+        # %%% Additional SHIBBOLETH_AUTHENTICATOR_CLASS parameters here %%% #
+
+    elif ( os.environ['AUTH_TYPE'] == "local" ):
+        print ("Authenticator: Using LDAP")
+        c.JupyterHub.authenticator_class = 'ldapauthenticator.LDAPAuthenticator'
+        c.LDAPAuthenticator.server_address = LDAP_URI
+        c.LDAPAuthenticator.use_ssl = False
+        c.LDAPAuthenticator.server_port = int(LDAP_PORT)
+        if (LDAP_URI[0:8] == "ldaps://"):
+          c.LDAPAuthenticator.use_ssl = True
+        c.LDAPAuthenticator.bind_dn_template = 'uid={username},'+LDAP_BASE_DN
+
+    else:
+        print ("ERROR: Authentication type not specified.")
+        print ("Cannot start JupyterHub.")
+
+
+    ### Configuration for single-user containers ###
+
+    # Spawn single-user's servers as Docker containers
+    c.JupyterHub.spawner_class = 'swanspawner.SwanDockerSpawner'
+    c.SwanSpawner.image = CONTAINER_IMAGE
+    c.SwanSpawner.remove_containers = True
+    c.SwanSpawner.options_form = '/srv/jupyterhub/jupyterhub_form.html'
+
+    # Instruct spawned containers to use the internal Docker network
+    c.SwanSpawner.use_internal_ip = True
+    c.SwanSpawner.network_name = DOCKER_NETWORK_NAME
+    c.SwanSpawner.extra_host_config = { 'network_mode': DOCKER_NETWORK_NAME }
+
+    # Single-user's servers extra config, CVMFS, EOS
+    #c.SwanSpawner.extra_host_config = { 'cap_drop': ['NET_BIND_SERVICE', 'SYS_CHROOT']}
+    c.SwanSpawner.read_only_volumes = { CVMFS_FOLDER : '/cvmfs' }
+
+    # Local home inside users' containers
+    #c.SwanSpawner.local_home = True		# If set to True, user <username> $HOME will be /scratch/<username>/
+    c.SwanSpawner.local_home = False
+    c.SwanSpawner.volumes = { EOS_USER_PATH : '/eos/user' }
+    c.SwanSpawner.available_cores = ["2", "4"]
+    c.SwanSpawner.available_memory = ["8", "10"]
+    c.SwanSpawner.check_cvmfs_status = False #For now it only checks if available in same place as Jupyterhub.
+
+    c.SwanSpawner.extra_env = dict(
+        SHARE_CBOX_API_DOMAIN = "https://%%%CERNBOXGATEWAY_HOSTNAME%%%",
+        SHARE_CBOX_API_BASE   = "/cernbox/swanapi/v1",
+        HELP_ENDPOINT         = "https://raw.githubusercontent.com/swan-cern/help/up2u/"
+    )
+
+    # local_home equal to true to hide the "always start with this config"
+    c.SpawnHandlersConfigs.local_home = True
+    c.SpawnHandlersConfigs.metrics_on = False #For now the metrics are hardcoded for CERN
+    c.SpawnHandlersConfigs.spawn_error_message = """SWAN could not start a session for your user, please try again. If the problem persists, please check:
+    <ul>
+        <li>Do you have a CERNBox account? If not, click <a href="https://%%%CERNBOXGATEWAY_HOSTNAME%%%" target="_blank">here</a>.</li>
+        <li>Check with the service manager that SWAN is running properly.</li>
+    </ul>"""
+
+  jupyterhub_form.complete.html: |-
+    <style> .nb{ font-weight:normal } </style>
+    <style> .nbs{ font-weight:normal; font-size:small } </style>
+    <script type="text/javascript">
+    <!--
+       function toggle_visibility(id) {
+          var e = document.getElementById(id);
+          if(e.style.display == 'block')
+             e.style.display = 'none';
+          else
+             e.style.display = 'block';
+       }
+    //-->
+    </script>
+    <br>
+    <label for="placeholder">
+    <span class='nb'>Specify the parameters that will be used to contextualise the container which is created for you. See <a target="_blank" href="https://swan.web.cern.ch/content/faq">the online SWAN guide</a> for more details.</span>
+    </label>
+    <br><br>
+    <label for="LCG-rel">Software stack <a href="#" onclick="toggle_visibility('lcgReleaseDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="lcgReleaseDetails">
+       <span class='nb'>The software stack to associate to the container. See the <a target="_blank" href="http://lcginfo.cern.ch/">LCG package info</a> page.</span>
+    </div>
+    </label>
+    <select name="LCG-rel">
+       <option style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0" disabled="disabled">Recommended releases (General Purpose)</option>
+       <option value="LCG_96" selected="">96</option>
+       <option value="LCG_96python3">96 Python3</option>
+       <option style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0" disabled="disabled"></option>
+       <option style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0" disabled="disabled">Development releases (might be unstable)</option>
+       <option value="dev3/latest">Bleeding Edge</option>
+       <option value="dev3python3/latest">Bleeding Edge Python3</option>
+       <option style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0" disabled="disabled"></option>
+       <option style="border-bottom:1px solid rgba(153,153,153,.3); margin:-10px 0 4px 0" disabled="disabled">Development releases (GPU)</option>
+       <option value="LCG_96py3cu10">Cuda 10 Python3</option>
+    </select>
+    <br>
+    <label for="platform">Platform <a href="#" onclick="toggle_visibility('platformDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="platformDetails">
+       <span class='nb'>The combination of compiler version and flags.</span>
+    </div>
+    </label>
+    <select name="platform">
+       <option value="x86_64-centos7-gcc8-opt" selected="">CentOS 7 (gcc8)</option>
+    </select>
+    <br>
+    <label for="scriptenv">Environment script <a href="#" onclick="toggle_visibility('scriptenvDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="scriptenvDetails">
+       <span class='nb'>User-provided bash script to define custom environment variables. The variable CERNBOX_HOME is resolved to the proper /eos/user/u/username directory.</span>
+    </div>
+    </label>
+    <input type="text" name="scriptenv" placeholder="e.g. $CERNBOX_HOME/MySWAN/myscript.sh">
+    <br>
+    <label for="ncores">Number of cores <a href="#" onclick="toggle_visibility('ncoresDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="ncoresDetails">
+       <span class='nb'>Number of cores to associate to the container.</span>
+    </div>
+    </label>
+    <select name="ncores">
+        <option value="2" selected>2</option>
+        <option value="4">4</option>
+    </select>
+    <br>
+    <label for="memory">Memory <a href="#" onclick="toggle_visibility('memoryDetails');"><span class='nbs'>more...</span></a>
+    <div style="display:none;" id="memoryDetails">
+       <span class='nb'>Amount of Memory allocated to the container.</span>
+    </div>
+    </label>
+    <select name="memory">
+        <option value="8" selected>8 GB</option>
+        <option value="10">10 GB</option>
+    </select>
+    <input type="hidden" name="spark-cluster" value="none"/>
+


### PR DESCRIPTION
The idea is:
- to move infrastructure/deployment specific details from docker image to the deployment yams
- the configuration of Jupiter notebook and extensions to be outsourced to deployment yaml (jupyterhub config and jupyterhub form). This allows updating Jupiter/Form/Configuration without need of updating jupyterhub image, and keep jupyterhub itself and jupyterhub image simple

Some discussion already followed with @diocas , @ebocchi @prasanthkothuri thoughts? 